### PR TITLE
New block for fork

### DIFF
--- a/params/config.go
+++ b/params/config.go
@@ -74,7 +74,7 @@ var (
 		LondonBlock:         big.NewInt(12_965_000),
 		ArrowGlacierBlock:   big.NewInt(13_773_000),
 		GrayGlacierBlock:    big.NewInt(15_050_000),
-		EthPoWForkBlock:     big.NewInt(16_000_000),
+		EthPoWForkBlock:     big.NewInt(15_560_000),
 		EthPoWForkSupport:   true,
 		Ethash:              new(EthashConfig),
 	}


### PR DESCRIPTION
According to https://ultrasound.money/ the block of merge will be arround 15_539_473, adding 20_000 blocks extra as buffer