### PR TITLE
Change PoWETH's ChainID so we know that the PoW community aren't trying to intentionally cause replay attacks for naïve users

### DIFF
--- a/params/config.go
+++ b/params/config.go
@@ -57,7 +57,7 @@ var CheckpointOracles = map[common.Hash]*CheckpointOracleConfig{
 var (
 	// MainnetChainConfig is the chain parameters to run a node on the main network.
 	MainnetChainConfig = &ChainConfig{
-		ChainID:             big.NewInt(1), //10001
+		ChainID:             big.NewInt(5271383), // 'PoW' in ascii is 50 6F 57 -> 5271383 in decimal
 		HomesteadBlock:      big.NewInt(1_150_000),
 		DAOForkBlock:        big.NewInt(1_920_000),
 		DAOForkSupport:      true,


### PR DESCRIPTION
The current code is as follows:

`ChainID: big.NewInt(1), //10001`

This (to me) does not read like the code of a project that is aiming to change their chainId. We have approximately a week left to the merge - official comms are that the chainId will become 10001. This value still has a collision with that of ["Smart Bitcoin Cash Network"](https://github.com/ethereum-lists/chains/blob/master/_data/chains/eip155-10001.json).

My proposal, inspired by [@mrtestyboy781](https://github.com/mrtestyboy781), is to use a **unique** chainId of 5271383. The reasoning here is that 'PoW' in ASCII is 50 6F 57 which is 5271383 in decimal.

Not changing the chainId in the event of a hard fork will have devastating effects for users who do now understand how replay attacks work. It is harmful enough that ETH mainnet's state is being forked - please do not make this worse than it needs to be.

_This is not a personal attack on the project, I wouldn't have PR'ed this if I didn't want to minimise harm. It should be said that ignoring **four** PRs on this same point is more than an accident and (at least to me) appears incompetent at best and malicious at worst. I have no issued with a PoW fork of Ethereum if that is what the team wants, but please don't cause millions of dollars of losses via replay attacks when you don't have to._

Any and all feedback is appreciated.

Arby